### PR TITLE
Update elixir erlang to match common-config

### DIFF
--- a/.github/workflows/common-config.yaml
+++ b/.github/workflows/common-config.yaml
@@ -38,8 +38,8 @@ jobs:
         uses: stordco/actions-elixir/setup@v1
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          elixir-version: "1.8.1"
-          otp-version: "23.1"
+          elixir-version: "1.16"
+          otp-version: "26.0"
 
       - name: Sync
         uses: stordco/actions-sync@v1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 23.1
-elixir 1.8.1
+elixir 1.16
+erlang 26.0

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule BambooPhoenix.MixProject do
     [
       app: :bamboo_phoenix,
       version: @version,
-      elixir: "~> 1.8",
+      elixir: "~> 1.16",
       source_url: @project_url,
       homepage_url: @project_url,
       start_permanent: Mix.env() == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -18,7 +18,7 @@
   "plug": {:hex, :plug, "1.11.0", "f17217525597628298998bc3baed9f8ea1fa3f1160aa9871aee6df47a6e4d38e", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.1.1 or ~> 1.2", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "2d9c633f0499f9dc5c2fd069161af4e2e7756890b81adcbb2ceaa074e8308876"},
   "plug_crypto": {:hex, :plug_crypto, "1.2.1", "5c854427528bf61d159855cedddffc0625e2228b5f30eff76d5a4de42d896ef4", [:mix], [], "hexpm", "6961c0e17febd9d0bfa89632d391d2545d2e0eb73768f5f50305a23961d8782c"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "telemetry": {:hex, :telemetry, "0.4.2", "2808c992455e08d6177322f14d3bdb6b625fbcfd233a73505870d8738a2f4599", [:rebar3], [], "hexpm", "2d1419bd9dda6a206d7b5852179511722e2b18812310d304620c7bd92a13fcef"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }


### PR DESCRIPTION
The old version of erlang was causing issues trying to install - [action run](https://github.com/beam-community/bamboo_phoenix/actions/runs/11443421999/job/31836026934). Instead of going down the rabbit hole and trying to patch this old version, elixir and erlang will need to be updated in the near future with the updates to use common-config, so I did it now. 

The update also required an update to `ssl_verify_fun` with the following warning when trying to compile:

```sh
src/ssl_verify_fun_cert_helpers.erl:64:1: Warning: function extract_dns_names_from_alt_names/2 is unused
%   64| extract_dns_names_from_alt_names([ExtValue | Rest], Acc) ->
%     | ^

could not compile dependency :ssl_verify_fun, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile ssl_verify_fun --force", update it with "mix deps.update ssl_verify_fun" or clean it with "mix deps.clean ssl_verify_fun"
```